### PR TITLE
feat(ui): add EmptyState for empty leaderboard

### DIFF
--- a/app/components/EmptyState.tsx
+++ b/app/components/EmptyState.tsx
@@ -1,0 +1,28 @@
+import { Users } from "lucide-react";
+
+type EmptyStateProps = {
+  title?: string;
+  description?: string;
+};
+
+export default function EmptyState({
+  title = "No builders found yet",
+  description = "Be the first to join the leaderboard",
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-14 px-4 text-center">
+      {/* Icon */}
+      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-gray-100">
+        <Users className="h-7 w-7 text-gray-400" />
+      </div>
+
+      {/* Text */}
+      <h3 className="text-base font-semibold text-gray-900">
+        {title}
+      </h3>
+      <p className="mt-1 text-sm text-gray-500 max-w-xs">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/app/components/Leaderboard.tsx
+++ b/app/components/Leaderboard.tsx
@@ -3,6 +3,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
+import EmptyState from "./EmptyState";
+
 
 type LeaderboardItem = {
   rank: number;
@@ -223,14 +225,17 @@ const Leaderboard = () => {
                         </td>
                     </tr>
                 )}
-                
-                {!loading && leaderboardData.length === 0 && (
-                    <tr>
-                        <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
-                            No data available.
-                        </td>
-                    </tr>
+               {!loading && leaderboardData.length === 0 && (
+                   <tr>
+                        <td colSpan={4}>
+                             <EmptyState
+                               title="No builders found yet"
+                               description="Be the first to join the leaderboard"
+                                   />
+                         </td>
+                      </tr>
                 )}
+
 
                 {leaderboardData.map((item) => {
                     let rankIcon = <span className="text-gray-500 font-mono font-medium">#{item.rank}</span>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "5.90.1",
         "@types/react": "18.3.11",
         "@types/react-dom": "18.3.1",
+        "canvas-confetti": "^1.9.3",
         "connectkit": "^1.9.1",
         "ethers": "^6.13.1",
         "next": "14.2.5",
@@ -24,6 +25,7 @@
         "wagmi": "2.17.2"
       },
       "devDependencies": {
+        "@types/canvas-confetti": "^1.6.4",
         "@types/node": "20.11.30",
         "autoprefixer": "10.4.20",
         "dotenv": "^17.2.3",
@@ -3510,6 +3512,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5334,6 +5343,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/cbw-sdk": {
       "name": "@coinbase/wallet-sdk",


### PR DESCRIPTION
### What changed
- Added a reusable EmptyState component
- Display EmptyState when leaderboard data is empty

### Why
- Improves user experience when leaderboard has no data

Closes #4
